### PR TITLE
Python3 compatibility

### DIFF
--- a/get_lds.py
+++ b/get_lds.py
@@ -3,10 +3,10 @@ import sys
 import os
 import numpy as np
 import glob
-try:     # Python2
-  import urllib2 as urllib
-except:  # Python3
-  import urllib
+if sys.version_info.major == 2:
+    from urllib2 import urlopen
+else:
+     from urllib.request import urlopen
 import argparse
 import scipy.interpolate as si
 from copy import copy
@@ -427,7 +427,7 @@ def ATLAS_model_search(s_met, s_grav, s_teff, s_vturb):
         # If not in the system, download it from Kurucz's website.
         # First, check all possible files to download:
         print('\t    + Model file not found.')
-        response = urllib.urlopen('http://kurucz.harvard.edu/grids/grid' +
+        response = urlopen('http://kurucz.harvard.edu/grids/grid' +
                                   met_dir + '/')
         html = response.read()
         ok = True
@@ -649,8 +649,8 @@ def PHOENIX_model_search(s_met, s_grav, s_teff, s_vturb):
        for i in np.arange(len(all_files)):
            all_files[i] = all_files[i].strip()
     else:
-       response = urllib.urlopen('ftp://phoenix.astro.physik.uni-goettingen.de/SpecIntFITS/PHOENIX-ACES-AGSS-COND-SPECINT-2011/'+model+'/')
-       html = response.read()
+       response = urlopen('ftp://phoenix.astro.physik.uni-goettingen.de/SpecIntFITS/PHOENIX-ACES-AGSS-COND-SPECINT-2011/'+model+'/')
+       html = str(response.read())
        all_files = []
        while True:
             idx = html.find('lte')

--- a/get_lds.py
+++ b/get_lds.py
@@ -429,7 +429,7 @@ def ATLAS_model_search(s_met, s_grav, s_teff, s_vturb):
         print('\t    + Model file not found.')
         response = urlopen('http://kurucz.harvard.edu/grids/grid' +
                                   met_dir + '/')
-        html = response.read()
+        html = str(response.read())
         ok = True
         filenames = []
         while(ok):


### PR DESCRIPTION
Hey Nestor,
This PR fixes some compatibility issues when trying to run `limb_darkening` on Python3.  Below there's a snippet that tests this PR (it's passing for me in Python 2 and 3.6).

```python
import os
import get_lds as lds

def test_urllib_phoenix():
    with open('test_passband.txt', 'w') as f:
        f.write("#lambda Transmission\n#(A)\n")
        for wl in range(3000, 3101):
            f.write("{:4d}  1.0\n".format(wl))
    try:
        os.remove('phoenix_models/raw_models/m00/lte06000-4.50-0.0.PHOENIX-ACES-AGSS-COND-SPECINT-2011.fits')
    except OSError:
        pass

    Teff = 6000.0
    grav = 4.5
    metal = 0.0
    vturb = -1.0
    RF = 'test_passband.txt'
    FT = 'P100'
    min_w = 3020.0
    max_w = 3070.0

    ldc = lds.lds(Teff, grav, metal, vturb, RF, FT, min_w, max_w)

    assert ldc == [(
        0.9568482869163394,
        1.0708732422831133,
        -0.1528011186396496,
        0.3739812981355847,
        0.8057122362109161,
        -0.28024218862258865,
        0.7074785718102249,
        -1.717966031243509,
        3.256211811234565,
        -1.2707421414358222,
        0.89778759805724,
        -0.13968175720857384,
        0.9667979921555729,
        0.0008263117390336841,
        1.1715597621589864,
        -0.3084696102653822
    )]

test_urllib_phoenix()
```